### PR TITLE
Various fixes from SCA runs

### DIFF
--- a/sirius-application/image-matching/detect.cpp
+++ b/sirius-application/image-matching/detect.cpp
@@ -173,7 +173,7 @@ void exec_match(po::variables_map &vm) {
   unsigned int runtimesearch = 0;
   unsigned int totaltime = 0;
   struct timeval tot1, tot2;
-  int numimgs = 0;
+  // int numimgs = 0;
 
   gettimeofday(&tot1, NULL);
   // classes

--- a/sirius-application/image-matching/detect.cpp
+++ b/sirius-application/image-matching/detect.cpp
@@ -56,7 +56,7 @@ string make_pbdesc(string img_name) {
 }
 
 vector<KeyPoint> exec_feature_gpu(const Mat &img_in,
-                                  const string detector_str) {
+                                  const string &detector_str) {
   vector<KeyPoint> keypoints;
   gpu::GpuMat img;
   img.upload(img_in);  // Only 8B grayscale
@@ -117,7 +117,7 @@ void exec_text(po::variables_map &vm) {
   tess->End();
 }
 
-Mat exec_desc_gpu(const Mat &img_in, const string extractor_str,
+Mat exec_desc_gpu(const Mat &img_in, const string &extractor_str,
                   vector<KeyPoint> keypoints) {
   gpu::GpuMat img;
   img.upload(img_in);  // Only 8B grayscale

--- a/sirius-suite/crf/baseline/crf.cpp
+++ b/sirius-suite/crf/baseline/crf.cpp
@@ -175,9 +175,9 @@ void CRF_Model::initialize_state_weights(const Sequence& seq) {
     powv.assign(_num_classes, 0.0);
     const Sample& s = seq.vs[i];
     for (vector<int>::const_iterator j = s.positive_features.begin();
-         j != s.positive_features.end(); j++) {
+         j != s.positive_features.end(); ++j) {
       for (vector<int>::const_iterator k = _feature2mef[*j].begin();
-           k != _feature2mef[*j].end(); k++) {
+           k != _feature2mef[*j].end(); ++k) {
         const double w = _vl[*k];
         powv[_fb.Feature(*k).label()] += w;
       }
@@ -360,22 +360,22 @@ int CRF_Model::make_feature_bag(const int cutoff) {
   map_type count;
   if (cutoff > 0) {
     for (vector<Sequence>::const_iterator k = _vs.begin(); k != _vs.end();
-         k++) {
+         ++k) {
       for (vector<Sample>::const_iterator i = k->vs.begin(); i != k->vs.end();
-           i++) {
+           ++i) {
         for (vector<int>::const_iterator j = i->positive_features.begin();
-             j != i->positive_features.end(); j++) {
+             j != i->positive_features.end(); ++j) {
           count[ME_Feature(i->label, *j).body()]++;
         }
       }
     }
   }
 
-  for (vector<Sequence>::const_iterator k = _vs.begin(); k != _vs.end(); k++) {
+  for (vector<Sequence>::const_iterator k = _vs.begin(); k != _vs.end(); ++k) {
     for (vector<Sample>::const_iterator i = k->vs.begin(); i != k->vs.end();
-         i++) {
+         ++i) {
       for (vector<int>::const_iterator j = i->positive_features.begin();
-           j != i->positive_features.end(); j++) {
+           j != i->positive_features.end(); ++j) {
         const ME_Feature feature(i->label, *j);
         if (cutoff > 0 && count[feature.body()] <= cutoff) continue;
         _fb.Put(feature);
@@ -394,7 +394,7 @@ double CRF_Model::heldout_likelihood() {
 
   initialize_edge_weights();
   for (std::vector<Sequence>::const_iterator i = _heldout.begin();
-       i != _heldout.end(); i++) {
+       i != _heldout.end(); ++i) {
     total_len += i->vs.size();
     double fp = forward_backward(*i);
     logl += calc_loglikelihood(*i);
@@ -424,9 +424,9 @@ void CRF_Model::add_sample_empirical_expectation(const Sequence& seq,
                                                  vector<double>& vee) {
   for (size_t i = 0; i < seq.vs.size(); i++) {
     for (vector<int>::const_iterator j = seq.vs[i].positive_features.begin();
-         j != seq.vs[i].positive_features.end(); j++) {
+         j != seq.vs[i].positive_features.end(); ++j) {
       for (vector<int>::const_iterator k = _feature2mef[*j].begin();
-           k != _feature2mef[*j].end(); k++) {
+           k != _feature2mef[*j].end(); ++k) {
         if (_fb.Feature(*k).label() == seq.vs[i].label) {
           assert(*k >= 0 && *k < _vee.size());
           _vee[*k] += 1.0;
@@ -459,9 +459,9 @@ double CRF_Model::add_sample_model_expectation(const Sequence& seq,
 
     vector<double> wsum = calc_state_weight(i);
     for (vector<int>::const_iterator j = s.positive_features.begin();
-         j != s.positive_features.end(); j++) {
+         j != s.positive_features.end(); ++j) {
       for (vector<int>::const_iterator k = _feature2mef[*j].begin();
-           k != _feature2mef[*j].end(); k++) {
+           k != _feature2mef[*j].end(); ++k) {
         vme[*k] += wsum[_fb.Feature(*k).label()];
       }
     }
@@ -507,7 +507,7 @@ double CRF_Model::update_model_expectation() {
   for (int i = 0; i < _fb.Size(); i++) _vme[i] = 0;
 
   initialize_edge_weights();
-  for (vector<Sequence>::const_iterator n = _vs.begin(); n != _vs.end(); n++) {
+  for (vector<Sequence>::const_iterator n = _vs.begin(); n != _vs.end(); ++n) {
     const Sequence& seq = *n;
     total_len += seq.vs.size();
     logl += add_sample_model_expectation(seq, _vme, ncorrect);
@@ -551,7 +551,7 @@ void CRF_Model::add_training_sample(const CRF_Sequence& seq) {
 
   Sequence s1;
   for (vector<CRF_State>::const_iterator i = seq.vs.begin(); i != seq.vs.end();
-       i++) {
+       ++i) {
     if (i->label == BOS_LABEL || i->label == EOS_LABEL) {
       cerr << "error: the label name \"" << i->label
            << "\" is reserved. Use a different name.";
@@ -569,7 +569,7 @@ void CRF_Model::add_training_sample(const CRF_Sequence& seq) {
     }
     assert(s.label >= 0 && s.label < MAX_LABEL_TYPES);
     for (vector<string>::const_iterator j = i->features.begin();
-         j != i->features.end(); j++) {
+         j != i->features.end(); ++j) {
       if (contain_space(*j)) {
         cerr << "error: the name of a feature must not contain any space."
              << endl;
@@ -629,7 +629,7 @@ int CRF_Model::train(const OptimizationMethod method, const int cutoff,
 
   int count = 0;
   for (vector<Sequence>::const_iterator n = _vs.begin(); n != _vs.end();
-       n++, count++) {
+       ++n, count++) {
     add_sample_empirical_expectation(*n, _vee);
   }
 
@@ -840,10 +840,10 @@ void CRF_Model::decode_forward_backward(CRF_Sequence& s0,
   Sequence seq;
 
   for (vector<CRF_State>::const_iterator i = s0.vs.begin(); i != s0.vs.end();
-       i++) {
+       ++i) {
     Sample s;
     for (vector<string>::const_iterator j = i->features.begin();
-         j != i->features.end(); j++) {
+         j != i->features.end(); ++j) {
       const int id = _featurename_bag.Id(*j);
       if (id >= 0) s.positive_features.push_back(id);
     }
@@ -858,7 +858,7 @@ void CRF_Model::decode_forward_backward(CRF_Sequence& s0,
     if (OUTPUT_MARGINAL_PROB) {
       double sum = 0;
       for (vector<double>::const_iterator j = wsum.begin(); j != wsum.end();
-           j++)
+           ++j)
         sum += *j;
       s0.vs[i].label = "";
       assert(abs(sum - 1) < 0.01);
@@ -891,10 +891,10 @@ void CRF_Model::decode_viterbi(CRF_Sequence& s0) {
   Sequence seq;
 
   for (vector<CRF_State>::const_iterator i = s0.vs.begin(); i != s0.vs.end();
-       i++) {
+       ++i) {
     Sample s;
     for (vector<string>::const_iterator j = i->features.begin();
-         j != i->features.end(); j++) {
+         j != i->features.end(); ++j) {
       const int id = _featurename_bag.Id(*j);
       if (id >= 0) s.positive_features.push_back(id);
     }
@@ -919,10 +919,10 @@ void CRF_Model::decode_nbest(CRF_Sequence& s0,
   Sequence seq;
 
   for (vector<CRF_State>::const_iterator i = s0.vs.begin(); i != s0.vs.end();
-       i++) {
+       ++i) {
     Sample s;
     for (vector<string>::const_iterator j = i->features.begin();
-         j != i->features.end(); j++) {
+         j != i->features.end(); ++j) {
       const int id = _featurename_bag.Id(*j);
       if (id >= 0) s.positive_features.push_back(id);
     }
@@ -939,7 +939,7 @@ void CRF_Model::decode_nbest(CRF_Sequence& s0,
   for (size_t i = 0; i < seq.vs.size(); i++) {
     s0.vs[i].label = _label_bag.Str(nb[0].vs[i]);
   }
-  for (vector<Path>::const_iterator i = nb.begin(); i != nb.end(); i++) {
+  for (vector<Path>::const_iterator i = nb.begin(); i != nb.end(); ++i) {
     if (i->score < min_prob) break;
     vector<string> vstr(i->vs.size());
     for (size_t j = 0; j < vstr.size(); j++) {
@@ -965,7 +965,7 @@ int CRF_Model::perform_AveragedPerceptron() {
     int error_num = 0;
     int rest = _vs.size();
     for (vector<Sequence>::const_iterator n = _vs.begin(); n != _vs.end();
-         n++, rest--) {
+         ++n, rest--) {
       const Sequence& seq = *n;
       vector<int> vs(seq.vs.size());
       viterbi(seq, vs);
@@ -985,9 +985,9 @@ int CRF_Model::perform_AveragedPerceptron() {
         const Sample& s = seq.vs[i];
         if (s.label == vs[i]) continue;
         for (vector<int>::const_iterator j = s.positive_features.begin();
-             j != s.positive_features.end(); j++) {
+             j != s.positive_features.end(); ++j) {
           for (vector<int>::const_iterator k = _feature2mef[*j].begin();
-               k != _feature2mef[*j].end(); k++) {
+               k != _feature2mef[*j].end(); ++k) {
             const int label = _fb.Feature(*k).label();
             if (label == s.label) X[*k] += 1.0;
             if (label == vs[i]) X[*k] -= 1.0;
@@ -1004,7 +1004,7 @@ int CRF_Model::perform_AveragedPerceptron() {
       }
 
       double wX = 0, X2 = 0;
-      for (map<int, double>::const_iterator i = X.begin(); i != X.end(); i++) {
+      for (map<int, double>::const_iterator i = X.begin(); i != X.end(); ++i) {
         wX += _vl[i->first] * i->second;
         X2 += i->second * i->second;
       }
@@ -1016,9 +1016,9 @@ int CRF_Model::perform_AveragedPerceptron() {
         if (s.label == vs[i]) continue;
 
         for (vector<int>::const_iterator j = s.positive_features.begin();
-             j != s.positive_features.end(); j++) {
+             j != s.positive_features.end(); ++j) {
           for (vector<int>::const_iterator k = _feature2mef[*j].begin();
-               k != _feature2mef[*j].end(); k++) {
+               k != _feature2mef[*j].end(); ++k) {
             const int label = _fb.Feature(*k).label();
             if (label == s.label) {
               _vl[*k] += a;

--- a/sirius-suite/crf/baseline/crf.cpp
+++ b/sirius-suite/crf/baseline/crf.cpp
@@ -1128,7 +1128,7 @@ int CRF_Model::perform_StochasticGradientDescent() {
 
   _vee.assign(_vee.size(), 0);
 
-  int iter = 0, k = 0, m;
+  int iter = 0, k = 0;
   const double eta0 = 1.0;
   const double tau = 5.0 * _vs.size() / batch_size;
   for (int iter = 0; iter < 20; iter++) {

--- a/sirius-suite/crf/baseline/crf.h
+++ b/sirius-suite/crf/baseline/crf.h
@@ -22,7 +22,7 @@
 struct CRF_State {
  public:
   CRF_State() : label(""){};
-  CRF_State(const std::string &l) : label(l){};
+  explicit CRF_State(const std::string &l) : label(l){};
   void set_label(const std::string &l) { label = l; }
 
   // to add a binary feature

--- a/sirius-suite/crf/baseline/crf.h
+++ b/sirius-suite/crf/baseline/crf.h
@@ -236,7 +236,7 @@ class CRF_Model {
       sprintf(buf, "%f\t", score);
       std::string s(buf);
       for (std::vector<int>::const_iterator i = vs.begin(); i != vs.end();
-           i++) {
+           ++i) {
         char buf[100];
         sprintf(buf, "%d ", *i);
         s += std::string(buf);

--- a/sirius-suite/crf/baseline/crfpos.cpp
+++ b/sirius-suite/crf/baseline/crfpos.cpp
@@ -104,7 +104,7 @@ static CRF_State crfstate(const vector<Token> &vt, int i) {
   }
   if (allupper) sample.add_feature("ALL_UPP");
 
-  if (WNdic.size() > 0) {
+  if (!WNdic.empty()) {
     const string n = normalize(str);
     for (map<string, string>::const_iterator i = WNdic.lower_bound(n);
          i != WNdic.upper_bound(n); i++) {

--- a/sirius-suite/crf/baseline/crfpos.cpp
+++ b/sirius-suite/crf/baseline/crfpos.cpp
@@ -107,7 +107,7 @@ static CRF_State crfstate(const vector<Token> &vt, int i) {
   if (!WNdic.empty()) {
     const string n = normalize(str);
     for (map<string, string>::const_iterator i = WNdic.lower_bound(n);
-         i != WNdic.upper_bound(n); i++) {
+         i != WNdic.upper_bound(n); ++i) {
       sample.add_feature("WN_" + i->second);
     }
   }
@@ -123,7 +123,7 @@ int crftrain(const CRF_Model::OptimizationMethod method, CRF_Model &m,
     exit(1);
   }
 
-  for (vector<Sentence>::const_iterator i = vs.begin(); i != vs.end(); i++) {
+  for (vector<Sentence>::const_iterator i = vs.begin(); i != vs.end(); ++i) {
     const Sentence &s = *i;
     CRF_Sequence cs;
     for (size_t j = 0; j < s.size(); j++) cs.add_state(crfstate(s, j));

--- a/sirius-suite/crf/baseline/lookahead.cpp
+++ b/sirius-suite/crf/baseline/lookahead.cpp
@@ -25,9 +25,9 @@ void CRF_Model::lookahead_initialize_state_weights(const Sequence &seq) {
     powv.assign(_num_classes, 0.0);
     const Sample &s = seq.vs[i];
     for (vector<int>::const_iterator j = s.positive_features.begin();
-         j != s.positive_features.end(); j++) {
+         j != s.positive_features.end(); ++j) {
       for (vector<int>::const_iterator k = _feature2mef[*j].begin();
-           k != _feature2mef[*j].end(); k++) {
+           k != _feature2mef[*j].end(); ++k) {
         const double w = _vl[*k];
         powv[_fb.Feature(*k).label()] += w;
       }
@@ -140,9 +140,9 @@ void CRF_Model::calc_diff(const double val, const Sequence &seq,
   assert(start + depth < (int)seq.vs.size());
   const Sample &s = seq.vs[start + depth];
   for (vector<int>::const_iterator j = s.positive_features.begin();
-       j != s.positive_features.end(); j++) {
+       j != s.positive_features.end(); ++j) {
     for (vector<int>::const_iterator k = _feature2mef[*j].begin();
-         k != _feature2mef[*j].end(); k++) {
+         k != _feature2mef[*j].end(); ++k) {
       if (_fb.Feature(*k).label() == label) diff[*k] += val;
     }
   }
@@ -151,7 +151,7 @@ void CRF_Model::calc_diff(const double val, const Sequence &seq,
 }
 
 static void print_bestsq(const vector<int> &bestsq) {
-  for (vector<int>::const_iterator i = bestsq.begin(); i != bestsq.end(); i++) {
+  for (vector<int>::const_iterator i = bestsq.begin(); i != bestsq.end(); ++i) {
     cout << *i << " ";
   }
   cout << endl;
@@ -178,7 +178,7 @@ int CRF_Model::update_weights_sub2(const Sequence &seq, vector<int> &history,
   calc_diff(-1, seq, x, history, 0, LOOKAHEAD_DEPTH, vdiff);
 
   for (map<int, double>::const_iterator j = vdiff.begin(); j != vdiff.end();
-       j++) {
+       ++j) {
     diff[j->first] += j->second;
   }
 
@@ -200,7 +200,7 @@ int CRF_Model::lookaheadtrain_sentence(const Sequence &seq, int &t,
     history[HV_OFFSET + x] = seq.vs[x].label;
 
     for (map<int, double>::const_iterator i = diff.begin(); i != diff.end();
-         i++) {
+         ++i) {
       const double v = 1.0 * i->second;
       _vl[i->first] += v;
       wa[i->first] += t * v;
@@ -215,7 +215,7 @@ double CRF_Model::heldout_lookahead_error() {
   int nerrors = 0, total_len = 0;
 
   for (std::vector<Sequence>::const_iterator i = _heldout.begin();
-       i != _heldout.end(); i++) {
+       i != _heldout.end(); ++i) {
     total_len += i->vs.size();
 
     vector<int> vs(i->vs.size());
@@ -303,10 +303,10 @@ void CRF_Model::decode_lookahead(CRF_Sequence &s0) {
   Sequence seq;
 
   for (vector<CRF_State>::const_iterator i = s0.vs.begin(); i != s0.vs.end();
-       i++) {
+       ++i) {
     Sample s;
     for (vector<string>::const_iterator j = i->features.begin();
-         j != i->features.end(); j++) {
+         j != i->features.end(); ++j) {
       const int id = _featurename_bag.Id(*j);
       if (id >= 0) s.positive_features.push_back(id);
     }

--- a/sirius-suite/crf/baseline/main.cpp
+++ b/sirius-suite/crf/baseline/main.cpp
@@ -138,7 +138,7 @@ int main(int argc, char **argv) {
 
     // convert parantheses
     vector<string> org_strs;
-    for (vector<Token>::iterator i = vt.begin(); i != vt.end(); i++) {
+    for (vector<Token>::iterator i = vt.begin(); i != vt.end(); ++i) {
       org_strs.push_back(i->str);
       i->str = paren_converter.Ptb2Pos(i->str);
       i->prd = "?";
@@ -157,7 +157,7 @@ int main(int argc, char **argv) {
       assert(0);
       exit(1);
     } else {
-      for (vector<Token>::const_iterator i = vt.begin(); i != vt.end(); i++) {
+      for (vector<Token>::const_iterator i = vt.begin(); i != vt.end(); ++i) {
         map<string, double> dummy;
         tagp1.push_back(dummy);
       }
@@ -172,13 +172,13 @@ int main(int argc, char **argv) {
 
       double sum = 0;
       for (map<string, double>::const_iterator j = crf.begin(); j != crf.end();
-           j++) {
+           ++j) {
         m.insert(pair<string, double>(j->first, j->second));
         sum += j->second;
       }
 
       for (map<string, double>::const_iterator j = ef.begin(); j != ef.end();
-           j++) {
+           ++j) {
         sum += j->second;
         if (m.find(j->first) == m.end()) {
           m.insert(pair<string, double>(j->first, j->second));
@@ -188,12 +188,12 @@ int main(int argc, char **argv) {
       }
 
       const double th = PROB_OUTPUT_THRESHOLD * sum;
-      for (map<string, double>::iterator j = m.begin(); j != m.end(); j++) {
+      for (map<string, double>::iterator j = m.begin(); j != m.end(); ++j) {
         if (j->second >= th) m2.insert(*j);
       }
       double maxp = -1;
       string maxtag;
-      for (map<string, double>::iterator j = m2.begin(); j != m2.end(); j++) {
+      for (map<string, double>::iterator j = m2.begin(); j != m2.end(); ++j) {
         const double p = j->second;
         if (p > maxp) {
           maxp = p;

--- a/sirius-suite/crf/baseline/strdic.h
+++ b/sirius-suite/crf/baseline/strdic.h
@@ -16,7 +16,7 @@ class StrDic {
  public:
   enum { LOAD_FACTOR = 2 };
 
-  StrDic(const int n = 1) { Clear(n); }
+  explicit StrDic(const int n = 1) { Clear(n); }
   ~StrDic() {
     for (size_t i = 0; i < _v.size(); i++) free(_v[i]);
   }

--- a/sirius-suite/crf/baseline/tokenize.cpp
+++ b/sirius-suite/crf/baseline/tokenize.cpp
@@ -173,7 +173,7 @@ void tokenize(const string& s, vector<Token>& vt,
   }
 
   int begin = 0;
-  for (vector<string>::const_iterator i = vs.begin(); i != vs.end(); i++) {
+  for (vector<string>::const_iterator i = vs.begin(); i != vs.end(); ++i) {
     string::size_type x = s.find(*i, begin);
     int strlen = i->size();
     if (*i == "''") {

--- a/sirius-suite/crf/pthread/crf.cpp
+++ b/sirius-suite/crf/pthread/crf.cpp
@@ -1129,7 +1129,7 @@ int CRF_Model::perform_StochasticGradientDescent() {
 
   _vee.assign(_vee.size(), 0);
 
-  int iter = 0, k = 0, m;
+  int iter = 0, k = 0;
   const double eta0 = 1.0;
   const double tau = 5.0 * _vs.size() / batch_size;
   for (int iter = 0; iter < 20; iter++) {

--- a/sirius-suite/crf/pthread/crf.cpp
+++ b/sirius-suite/crf/pthread/crf.cpp
@@ -175,9 +175,9 @@ void CRF_Model::initialize_state_weights(const Sequence& seq) {
     powv.assign(_num_classes, 0.0);
     const Sample& s = seq.vs[i];
     for (vector<int>::const_iterator j = s.positive_features.begin();
-         j != s.positive_features.end(); j++) {
+         j != s.positive_features.end(); ++j) {
       for (vector<int>::const_iterator k = _feature2mef[*j].begin();
-           k != _feature2mef[*j].end(); k++) {
+           k != _feature2mef[*j].end(); ++k) {
         const double w = _vl[*k];
         powv[_fb.Feature(*k).label()] += w;
       }
@@ -360,22 +360,22 @@ int CRF_Model::make_feature_bag(const int cutoff) {
   map_type count;
   if (cutoff > 0) {
     for (vector<Sequence>::const_iterator k = _vs.begin(); k != _vs.end();
-         k++) {
+         ++k) {
       for (vector<Sample>::const_iterator i = k->vs.begin(); i != k->vs.end();
-           i++) {
+           ++i) {
         for (vector<int>::const_iterator j = i->positive_features.begin();
-             j != i->positive_features.end(); j++) {
+             j != i->positive_features.end(); ++j) {
           count[ME_Feature(i->label, *j).body()]++;
         }
       }
     }
   }
 
-  for (vector<Sequence>::const_iterator k = _vs.begin(); k != _vs.end(); k++) {
+  for (vector<Sequence>::const_iterator k = _vs.begin(); k != _vs.end(); ++k) {
     for (vector<Sample>::const_iterator i = k->vs.begin(); i != k->vs.end();
-         i++) {
+         ++i) {
       for (vector<int>::const_iterator j = i->positive_features.begin();
-           j != i->positive_features.end(); j++) {
+           j != i->positive_features.end(); ++j) {
         const ME_Feature feature(i->label, *j);
         if (cutoff > 0 && count[feature.body()] <= cutoff) continue;
         _fb.Put(feature);
@@ -394,7 +394,7 @@ double CRF_Model::heldout_likelihood() {
 
   initialize_edge_weights();
   for (std::vector<Sequence>::const_iterator i = _heldout.begin();
-       i != _heldout.end(); i++) {
+       i != _heldout.end(); ++i) {
     total_len += i->vs.size();
     double fp = forward_backward(*i);
     logl += calc_loglikelihood(*i);
@@ -424,9 +424,9 @@ void CRF_Model::add_sample_empirical_expectation(const Sequence& seq,
                                                  vector<double>& vee) {
   for (size_t i = 0; i < seq.vs.size(); i++) {
     for (vector<int>::const_iterator j = seq.vs[i].positive_features.begin();
-         j != seq.vs[i].positive_features.end(); j++) {
+         j != seq.vs[i].positive_features.end(); ++j) {
       for (vector<int>::const_iterator k = _feature2mef[*j].begin();
-           k != _feature2mef[*j].end(); k++) {
+           k != _feature2mef[*j].end(); ++k) {
         if (_fb.Feature(*k).label() == seq.vs[i].label) {
           assert(*k >= 0 && *k < _vee.size());
           _vee[*k] += 1.0;
@@ -460,9 +460,9 @@ double CRF_Model::add_sample_model_expectation(const Sequence& seq,
     // model expectation (state)
     vector<double> wsum = calc_state_weight(i);
     for (vector<int>::const_iterator j = s.positive_features.begin();
-         j != s.positive_features.end(); j++) {
+         j != s.positive_features.end(); ++j) {
       for (vector<int>::const_iterator k = _feature2mef[*j].begin();
-           k != _feature2mef[*j].end(); k++) {
+           k != _feature2mef[*j].end(); ++k) {
         vme[*k] += wsum[_fb.Feature(*k).label()];
       }
     }
@@ -508,7 +508,7 @@ double CRF_Model::update_model_expectation() {
   for (int i = 0; i < _fb.Size(); i++) _vme[i] = 0;
 
   initialize_edge_weights();
-  for (vector<Sequence>::const_iterator n = _vs.begin(); n != _vs.end(); n++) {
+  for (vector<Sequence>::const_iterator n = _vs.begin(); n != _vs.end(); ++n) {
     const Sequence& seq = *n;
     total_len += seq.vs.size();
     logl += add_sample_model_expectation(seq, _vme, ncorrect);
@@ -552,7 +552,7 @@ void CRF_Model::add_training_sample(const CRF_Sequence& seq) {
 
   Sequence s1;
   for (vector<CRF_State>::const_iterator i = seq.vs.begin(); i != seq.vs.end();
-       i++) {
+       ++i) {
     if (i->label == BOS_LABEL || i->label == EOS_LABEL) {
       cerr << "error: the label name \"" << i->label
            << "\" is reserved. Use a different name.";
@@ -570,7 +570,7 @@ void CRF_Model::add_training_sample(const CRF_Sequence& seq) {
     }
     assert(s.label >= 0 && s.label < MAX_LABEL_TYPES);
     for (vector<string>::const_iterator j = i->features.begin();
-         j != i->features.end(); j++) {
+         j != i->features.end(); ++j) {
       if (contain_space(*j)) {
         cerr << "error: the name of a feature must not contain any space."
              << endl;
@@ -630,7 +630,7 @@ int CRF_Model::train(const OptimizationMethod method, const int cutoff,
 
   int count = 0;
   for (vector<Sequence>::const_iterator n = _vs.begin(); n != _vs.end();
-       n++, count++) {
+       ++n, count++) {
     add_sample_empirical_expectation(*n, _vee);
   }
 
@@ -841,10 +841,10 @@ void CRF_Model::decode_forward_backward(CRF_Sequence& s0,
   Sequence seq;
 
   for (vector<CRF_State>::const_iterator i = s0.vs.begin(); i != s0.vs.end();
-       i++) {
+       ++i) {
     Sample s;
     for (vector<string>::const_iterator j = i->features.begin();
-         j != i->features.end(); j++) {
+         j != i->features.end(); ++j) {
       const int id = _featurename_bag.Id(*j);
       if (id >= 0) s.positive_features.push_back(id);
     }
@@ -859,7 +859,7 @@ void CRF_Model::decode_forward_backward(CRF_Sequence& s0,
     if (OUTPUT_MARGINAL_PROB) {
       double sum = 0;
       for (vector<double>::const_iterator j = wsum.begin(); j != wsum.end();
-           j++)
+           ++j)
         sum += *j;
       s0.vs[i].label = "";
       assert(abs(sum - 1) < 0.01);
@@ -892,10 +892,10 @@ void CRF_Model::decode_viterbi(CRF_Sequence& s0) {
   Sequence seq;
 
   for (vector<CRF_State>::const_iterator i = s0.vs.begin(); i != s0.vs.end();
-       i++) {
+       ++i) {
     Sample s;
     for (vector<string>::const_iterator j = i->features.begin();
-         j != i->features.end(); j++) {
+         j != i->features.end(); ++j) {
       const int id = _featurename_bag.Id(*j);
       if (id >= 0) s.positive_features.push_back(id);
     }
@@ -920,10 +920,10 @@ void CRF_Model::decode_nbest(CRF_Sequence& s0,
   Sequence seq;
 
   for (vector<CRF_State>::const_iterator i = s0.vs.begin(); i != s0.vs.end();
-       i++) {
+       ++i) {
     Sample s;
     for (vector<string>::const_iterator j = i->features.begin();
-         j != i->features.end(); j++) {
+         j != i->features.end(); ++j) {
       const int id = _featurename_bag.Id(*j);
       if (id >= 0) s.positive_features.push_back(id);
     }
@@ -940,7 +940,7 @@ void CRF_Model::decode_nbest(CRF_Sequence& s0,
   for (size_t i = 0; i < seq.vs.size(); i++) {
     s0.vs[i].label = _label_bag.Str(nb[0].vs[i]);
   }
-  for (vector<Path>::const_iterator i = nb.begin(); i != nb.end(); i++) {
+  for (vector<Path>::const_iterator i = nb.begin(); i != nb.end(); ++i) {
     if (i->score < min_prob) break;
     vector<string> vstr(i->vs.size());
     for (size_t j = 0; j < vstr.size(); j++) {
@@ -966,7 +966,7 @@ int CRF_Model::perform_AveragedPerceptron() {
     int error_num = 0;
     int rest = _vs.size();
     for (vector<Sequence>::const_iterator n = _vs.begin(); n != _vs.end();
-         n++, rest--) {
+         ++n, rest--) {
       const Sequence& seq = *n;
       vector<int> vs(seq.vs.size());
       viterbi(seq, vs);
@@ -986,9 +986,9 @@ int CRF_Model::perform_AveragedPerceptron() {
         const Sample& s = seq.vs[i];
         if (s.label == vs[i]) continue;
         for (vector<int>::const_iterator j = s.positive_features.begin();
-             j != s.positive_features.end(); j++) {
+             j != s.positive_features.end(); ++j) {
           for (vector<int>::const_iterator k = _feature2mef[*j].begin();
-               k != _feature2mef[*j].end(); k++) {
+               k != _feature2mef[*j].end(); ++k) {
             const int label = _fb.Feature(*k).label();
             if (label == s.label) X[*k] += 1.0;
             if (label == vs[i]) X[*k] -= 1.0;
@@ -1005,7 +1005,7 @@ int CRF_Model::perform_AveragedPerceptron() {
       }
 
       double wX = 0, X2 = 0;
-      for (map<int, double>::const_iterator i = X.begin(); i != X.end(); i++) {
+      for (map<int, double>::const_iterator i = X.begin(); i != X.end(); ++i) {
         wX += _vl[i->first] * i->second;
         X2 += i->second * i->second;
       }
@@ -1017,9 +1017,9 @@ int CRF_Model::perform_AveragedPerceptron() {
         if (s.label == vs[i]) continue;
 
         for (vector<int>::const_iterator j = s.positive_features.begin();
-             j != s.positive_features.end(); j++) {
+             j != s.positive_features.end(); ++j) {
           for (vector<int>::const_iterator k = _feature2mef[*j].begin();
-               k != _feature2mef[*j].end(); k++) {
+               k != _feature2mef[*j].end(); ++k) {
             const int label = _fb.Feature(*k).label();
             if (label == s.label) {
               _vl[*k] += a;

--- a/sirius-suite/crf/pthread/crf.h
+++ b/sirius-suite/crf/pthread/crf.h
@@ -22,7 +22,7 @@
 struct CRF_State {
  public:
   CRF_State() : label(""){};
-  CRF_State(const std::string &l) : label(l){};
+  explicit CRF_State(const std::string &l) : label(l){};
   void set_label(const std::string &l) { label = l; }
 
   // to add a binary feature

--- a/sirius-suite/crf/pthread/crf.h
+++ b/sirius-suite/crf/pthread/crf.h
@@ -236,7 +236,7 @@ class CRF_Model {
       sprintf(buf, "%f\t", score);
       std::string s(buf);
       for (std::vector<int>::const_iterator i = vs.begin(); i != vs.end();
-           i++) {
+           ++i) {
         char buf[100];
         sprintf(buf, "%d ", *i);
         s += std::string(buf);

--- a/sirius-suite/crf/pthread/crfpos.cpp
+++ b/sirius-suite/crf/pthread/crfpos.cpp
@@ -104,7 +104,7 @@ static CRF_State crfstate(const vector<Token> &vt, int i) {
   }
   if (allupper) sample.add_feature("ALL_UPP");
 
-  if (WNdic.size() > 0) {
+  if (!WNdic.empty()) {
     const string n = normalize(str);
     for (map<string, string>::const_iterator i = WNdic.lower_bound(n);
          i != WNdic.upper_bound(n); i++) {

--- a/sirius-suite/crf/pthread/crfpos.cpp
+++ b/sirius-suite/crf/pthread/crfpos.cpp
@@ -107,7 +107,7 @@ static CRF_State crfstate(const vector<Token> &vt, int i) {
   if (!WNdic.empty()) {
     const string n = normalize(str);
     for (map<string, string>::const_iterator i = WNdic.lower_bound(n);
-         i != WNdic.upper_bound(n); i++) {
+         i != WNdic.upper_bound(n); ++i) {
       sample.add_feature("WN_" + i->second);
     }
   }
@@ -123,7 +123,7 @@ int crftrain(const CRF_Model::OptimizationMethod method, CRF_Model &m,
     exit(1);
   }
 
-  for (vector<Sentence>::const_iterator i = vs.begin(); i != vs.end(); i++) {
+  for (vector<Sentence>::const_iterator i = vs.begin(); i != vs.end(); ++i) {
     const Sentence &s = *i;
     CRF_Sequence cs;
     for (size_t j = 0; j < s.size(); j++) cs.add_state(crfstate(s, j));

--- a/sirius-suite/crf/pthread/lookahead.cpp
+++ b/sirius-suite/crf/pthread/lookahead.cpp
@@ -25,9 +25,9 @@ void CRF_Model::lookahead_initialize_state_weights(const Sequence &seq) {
     powv.assign(_num_classes, 0.0);
     const Sample &s = seq.vs[i];
     for (vector<int>::const_iterator j = s.positive_features.begin();
-         j != s.positive_features.end(); j++) {
+         j != s.positive_features.end(); ++j) {
       for (vector<int>::const_iterator k = _feature2mef[*j].begin();
-           k != _feature2mef[*j].end(); k++) {
+           k != _feature2mef[*j].end(); ++k) {
         const double w = _vl[*k];
         powv[_fb.Feature(*k).label()] += w;
       }
@@ -140,9 +140,9 @@ void CRF_Model::calc_diff(const double val, const Sequence &seq,
   assert(start + depth < (int)seq.vs.size());
   const Sample &s = seq.vs[start + depth];
   for (vector<int>::const_iterator j = s.positive_features.begin();
-       j != s.positive_features.end(); j++) {
+       j != s.positive_features.end(); ++j) {
     for (vector<int>::const_iterator k = _feature2mef[*j].begin();
-         k != _feature2mef[*j].end(); k++) {
+         k != _feature2mef[*j].end(); ++k) {
       if (_fb.Feature(*k).label() == label) diff[*k] += val;
     }
   }
@@ -151,7 +151,7 @@ void CRF_Model::calc_diff(const double val, const Sequence &seq,
 }
 
 static void print_bestsq(const vector<int> &bestsq) {
-  for (vector<int>::const_iterator i = bestsq.begin(); i != bestsq.end(); i++) {
+  for (vector<int>::const_iterator i = bestsq.begin(); i != bestsq.end(); ++i) {
     cout << *i << " ";
   }
   cout << endl;
@@ -178,7 +178,7 @@ int CRF_Model::update_weights_sub2(const Sequence &seq, vector<int> &history,
   calc_diff(-1, seq, x, history, 0, LOOKAHEAD_DEPTH, vdiff);
 
   for (map<int, double>::const_iterator j = vdiff.begin(); j != vdiff.end();
-       j++) {
+       ++j) {
     diff[j->first] += j->second;
   }
 
@@ -200,7 +200,7 @@ int CRF_Model::lookaheadtrain_sentence(const Sequence &seq, int &t,
     history[HV_OFFSET + x] = seq.vs[x].label;
 
     for (map<int, double>::const_iterator i = diff.begin(); i != diff.end();
-         i++) {
+         ++i) {
       const double v = 1.0 * i->second;
       _vl[i->first] += v;
       wa[i->first] += t * v;
@@ -215,7 +215,7 @@ double CRF_Model::heldout_lookahead_error() {
   int nerrors = 0, total_len = 0;
 
   for (std::vector<Sequence>::const_iterator i = _heldout.begin();
-       i != _heldout.end(); i++) {
+       i != _heldout.end(); ++i) {
     total_len += i->vs.size();
 
     vector<int> vs(i->vs.size());
@@ -303,10 +303,10 @@ void CRF_Model::decode_lookahead(CRF_Sequence &s0) {
   Sequence seq;
 
   for (vector<CRF_State>::const_iterator i = s0.vs.begin(); i != s0.vs.end();
-       i++) {
+       ++i) {
     Sample s;
     for (vector<string>::const_iterator j = i->features.begin();
-         j != i->features.end(); j++) {
+         j != i->features.end(); ++j) {
       const int id = _featurename_bag.Id(*j);
       if (id >= 0) s.positive_features.push_back(id);
     }

--- a/sirius-suite/crf/pthread/main.cpp
+++ b/sirius-suite/crf/pthread/main.cpp
@@ -80,7 +80,7 @@ void *crf_thread(void *tid) {
 
     // convert parantheses
     vector<string> org_strs;
-    for (vector<Token>::iterator i = vt.begin(); i != vt.end(); i++) {
+    for (vector<Token>::iterator i = vt.begin(); i != vt.end(); ++i) {
       org_strs.push_back(i->str);
       i->str = paren_converter.Ptb2Pos(i->str);
       i->prd = "?";
@@ -93,7 +93,7 @@ void *crf_thread(void *tid) {
       assert(0);
       exit(1);
     } else {
-      for (vector<Token>::const_iterator i = vt.begin(); i != vt.end(); i++) {
+      for (vector<Token>::const_iterator i = vt.begin(); i != vt.end(); ++i) {
         map<string, double> dummy;
         tagp1.push_back(dummy);
       }
@@ -108,13 +108,13 @@ void *crf_thread(void *tid) {
 
       double sum = 0;
       for (map<string, double>::const_iterator j = crf.begin(); j != crf.end();
-           j++) {
+           ++j) {
         m.insert(pair<string, double>(j->first, j->second));
         sum += j->second;
       }
 
       for (map<string, double>::const_iterator j = ef.begin(); j != ef.end();
-           j++) {
+           ++j) {
         sum += j->second;
         if (m.find(j->first) == m.end()) {
           m.insert(pair<string, double>(j->first, j->second));
@@ -124,12 +124,12 @@ void *crf_thread(void *tid) {
       }
 
       const double th = PROB_OUTPUT_THRESHOLD * sum;
-      for (map<string, double>::iterator j = m.begin(); j != m.end(); j++) {
+      for (map<string, double>::iterator j = m.begin(); j != m.end(); ++j) {
         if (j->second >= th) m2.insert(*j);
       }
       double maxp = -1;
       string maxtag;
-      for (map<string, double>::iterator j = m2.begin(); j != m2.end(); j++) {
+      for (map<string, double>::iterator j = m2.begin(); j != m2.end(); ++j) {
         const double p = j->second;
         if (p > maxp) {
           maxp = p;

--- a/sirius-suite/crf/pthread/tokenize.cpp
+++ b/sirius-suite/crf/pthread/tokenize.cpp
@@ -175,7 +175,7 @@ void tokenize(const string& s, vector<Token>& vt,
   }
 
   int begin = 0;
-  for (vector<string>::const_iterator i = vs.begin(); i != vs.end(); i++) {
+  for (vector<string>::const_iterator i = vs.begin(); i != vs.end(); ++i) {
     string::size_type x = s.find(*i, begin);
     int strlen = i->size();
     if (*i == "''") {

--- a/sirius-suite/dnn-asr/gpu/dnn-asr.cpp
+++ b/sirius-suite/dnn-asr/gpu/dnn-asr.cpp
@@ -154,6 +154,6 @@ int main(int argc, char** argv) {
     assert(isEqual(correct_out[i], dnn_output[i]));
 
 #endif
-
+  free(dnn_output);
   return 0;
 }

--- a/sirius-suite/fd/pthread/surf-fd.cpp
+++ b/sirius-suite/fd/pthread/surf-fd.cpp
@@ -181,7 +181,7 @@ int main(int argc, char **argv) {
   PRINT_STAT_DOUBLE("tiling", toc());
 
   tic();
-  int start, tids[NTHREADS];
+  int tids[NTHREADS];
   pthread_t threads[NTHREADS];
   pthread_attr_t attr;
   iterations = (segs.size() / NTHREADS);

--- a/sirius-suite/fe/pthread/surf-fe.cpp
+++ b/sirius-suite/fe/pthread/surf-fe.cpp
@@ -159,7 +159,7 @@ int main(int argc, char **argv) {
   PRINT_STAT_DOUBLE("tiling", toc());
 
   tic();
-  int start, tids[NTHREADS];
+  int tids[NTHREADS];
   pthread_t threads[NTHREADS];
   pthread_attr_t attr;
   iterations = (segs.size() / NTHREADS);
@@ -183,7 +183,6 @@ int main(int argc, char **argv) {
   int i = 0, r, c;
   CvRect roi;
   Mat output(img.size().height, img.size().width, img.type(), Scalar(0));
-  vector<KeyPoint> key;
   // load color to write color keys
   Mat img2 = imread(argv[3]);
   int height_inc = img.size().height / NTHREADS;
@@ -191,7 +190,6 @@ int main(int argc, char **argv) {
 
   roi.width = width;
   roi.height = height;
-  int count = 0;
   for (r = 0; r < img.size().height; r += height_inc) {
     for (c = 0; c < img.size().width; c += width_inc) {
       Mat temp = segs[i].clone();

--- a/sirius-suite/regex/baseline/main.cpp
+++ b/sirius-suite/regex/baseline/main.cpp
@@ -91,12 +91,14 @@ int main(int argc, char *argv[]) {
   PRINT_STAT_DOUBLE("regex", toc());
 
 #ifdef TESTING
+  fclose(f);
   f = fopen("../input/regex_slre.baseline", "w");
 
   for (int i = 0; i < numExps * numQs; ++i) fprintf(f, "%s\n", caps[i]->ptr);
 
-  fclose(f);
 #endif
+  fclose(f);
+  fclose(f1);
 
   STATS_END();
 

--- a/sirius-suite/regex/pthread/main.cpp
+++ b/sirius-suite/regex/pthread/main.cpp
@@ -134,12 +134,14 @@ int main(int argc, char *argv[]) {
   PRINT_STAT_DOUBLE("pthread_regex", toc());
 
 #ifdef TESTING
+  fclose(f);
   f = fopen("../input/regex_slre.pthread", "w");
 
   for (int i = 0; i < numExps * numQs; ++i) fprintf(f, "%s\n", caps[i]->ptr);
 
-  fclose(f);
 #endif
+  fclose(f);
+  fclose(f1);
 
   sirius_free(caps);
 

--- a/sirius-suite/regex/pthread/slre.cpp
+++ b/sirius-suite/regex/pthread/slre.cpp
@@ -118,10 +118,10 @@ static void print_character_set(FILE *fp, const unsigned char *p, int len) {
 }
 
 void slre_dump(const struct slre *r, FILE *fp) {
-  int i, j, ch, op, pc;
+  int i, j, ch, pc;
 
   for (pc = 0; pc < r->code_size; pc++) {
-    op = r->code[pc];
+    int op = r->code[pc];
     (void)fprintf(fp, "%3d %s ", pc, opcodes[op].name);
 
     for (i = 0; opcodes[op].flags[i] != '\0'; i++)
@@ -589,12 +589,12 @@ static int match(const struct slre *r, int pc, const char *s, int len, int *ofs,
 
 int slre_match(const struct slre *r, const char *buf, int len,
                struct cap *caps) {
-  int i, ofs = 0, res = 0;
+  int ofs = 0, res = 0;
 
   if (r->anchored) {
     res = match(r, 0, buf, len, &ofs, caps);
   } else {
-    for (i = 0; i < len && res == 0; i++) {
+    for (int i = 0; i < len && res == 0; i++) {
       ofs = i;
       res = match(r, 0, buf, len, &ofs, caps);
     }

--- a/sirius-suite/stemmer/pthread/main.cpp
+++ b/sirius-suite/stemmer/pthread/main.cpp
@@ -6,6 +6,7 @@
 #include <stdlib.h> /* for malloc, free */
 #include <ctype.h>  /* for isupper, islower, tolower */
 #include <pthread.h>
+#include <errno.h>
 
 #include "../../utils/timer.h"
 #include "../../utils/memoryman.h"
@@ -53,7 +54,12 @@ int load_data(struct stemmer **stem_list, FILE *f) {
       while (TRUE) {
         if (i == i_max) {
           i_max += INC;
-          s = (char *)realloc(s, i_max + 1);
+          void *_realloc = NULL;
+          if ((_realloc = realloc(s, i_max + 1)) == NULL) {
+            fprintf(stderr, "realloc() failed!\n");
+            return -ENOMEM; 
+          }
+          s = (char*)_realloc;
         }
         ch = tolower(ch); /* forces lower case */
 
@@ -71,7 +77,12 @@ int load_data(struct stemmer **stem_list, FILE *f) {
       stem_list[a_size] = z;
       if (a_size == a_max) {
         a_max += A_INC;
-        stem_list = (struct stemmer **)realloc(stem_list, a_max);
+        void *_realloc = NULL;
+        if ((_realloc = realloc(stem_list, a_max)) == NULL) {
+            fprintf(stderr, "realloc() failed!\n");
+            return -ENOMEM; 
+        }
+        stem_list = (struct stemmer **)_realloc;
       }
       a_size += 1;
     }
@@ -102,6 +113,10 @@ int main(int argc, char *argv[]) {
       (struct stemmer **)sirius_malloc(ARRAYSIZE * sizeof(struct stemmer *));
   int words = load_data(stem_list, f);
   fclose(f);
+ 
+ if (words < 0)
+    goto out;
+
   PRINT_STAT_INT("words", words);
 
   tic();
@@ -132,6 +147,7 @@ int main(int argc, char *argv[]) {
   fclose(f);
 #endif
 
+out:
   sirius_free(s);
 
   // free up allocated data


### PR DESCRIPTION
- remove unused vars
- make ctor explicit
- fix realloc memory leaks
- reduce scope of vars
- fix resource leaks (close files)
- fix memory leaks
- prefer prefix ++operator for non-primitive types
- use !empty() instead of 'size() > 0'