### PR TITLE
add a check to ensure the compile-sirius-servers.sh script can't be executed as root

### DIFF
--- a/sirius-application/compile-sirius-servers.sh
+++ b/sirius-application/compile-sirius-servers.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+# check to make sure we're not being executed as root.
+if [ "$(id -u)" == "0" ]; then
+  echo >&2 "Do not run this script as root or with sudo."
+  exit 1
+fi
+
 # exit if any server fails
 set -e
 


### PR DESCRIPTION
This is a fix for https://github.com/jhauswald/sirius/issues/36 

"Do not advise users to run "./compile-sirius-servers.sh" with root privileges"