### PR TITLE
Set the minimum thread count is 8

### DIFF
--- a/sirius-application/run-scripts/start-qa-server.sh
+++ b/sirius-application/run-scripts/start-qa-server.sh
@@ -35,6 +35,9 @@ export CLASSPATH=bin:lib/ml/maxent.jar:lib/ml/minorthird.jar:lib/nlp/jwnl.jar:li
 
 export INDRI_INDEX=`pwd`/wiki_indri_index/
 export THREADS=$(cat /proc/cpuinfo | grep processor | wc -l)
+if [ $THREADS -lt 8 ]; then
+  export THREADS=8
+fi
 
 java -Djava.library.path=lib/search/ -server -Xms1024m -Xmx2048m \
   info.ephyra.OpenEphyraServer $ip $port


### PR DESCRIPTION
The last start-qa-server.sh sets THREADS based on count of processors in /proc/cpuinfo .
However, in the single core server, jetty warns the environment is insufficient and doesn't response for http requests.

```
<< stderr by start-qa-server.sh >>
2015-04-18 14:36:55.456:WARN:oejs.AbstractConnector:insufficient threads configured for SelectChannelConnector@localhost:8080
```

The simple solution is that the script sets the minimum thread count is 8.